### PR TITLE
Add missing dependency tag for visualization_msgs

### DIFF
--- a/tesseract_ros/tesseract_monitoring/package.xml
+++ b/tesseract_ros/tesseract_monitoring/package.xml
@@ -13,6 +13,7 @@
   <build_export_depend>rclcpp</build_export_depend>
   <exec_depend>rclcpp</exec_depend>
   <depend>eigen</depend>
+  <depend>orocos-kdl</depend>
   <depend>tesseract</depend>
   <depend>tesseract_rosutils</depend>
   <depend>tesseract_msgs</depend>

--- a/tesseract_ros/tesseract_plugins/package.xml
+++ b/tesseract_ros/tesseract_plugins/package.xml
@@ -17,6 +17,8 @@
   <depend>tesseract_collision</depend>
   <depend>pluginlib</depend>
 
+  <depend>eigen</depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
       <build_type>ament_cmake</build_type>

--- a/tesseract_ros/tesseract_rosutils/package.xml
+++ b/tesseract_ros/tesseract_rosutils/package.xml
@@ -18,7 +18,11 @@
   <depend>tesseract_visualization</depend>
   <depend>tesseract_common</depend>
   <depend>tesseract_process_planners</depend>
+
   <depend>visualization_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2_eigen</depend>
+  <depend>ament_index_cpp</depend>
 
   <depend>octomap</depend>
 

--- a/tesseract_ros/tesseract_rosutils/package.xml
+++ b/tesseract_ros/tesseract_rosutils/package.xml
@@ -18,6 +18,7 @@
   <depend>tesseract_visualization</depend>
   <depend>tesseract_common</depend>
   <depend>tesseract_process_planners</depend>
+  <depend>visualization_msgs</depend>
 
   <depend>octomap</depend>
 


### PR DESCRIPTION
There's a `find_package(visualization_msgs REQUIRED)` in `tesseract_rosutils`, so CI will fail to build this package since `ros-$DISTRO-visualization-msgs` won't be installed.