### PR TITLE
Remove unneeded dependencies on orocos-kdl library

### DIFF
--- a/tesseract_ros/tesseract_monitoring/CMakeLists.txt
+++ b/tesseract_ros/tesseract_monitoring/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 project(tesseract_monitoring VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(tesseract REQUIRED)
-find_package(orocos_kdl REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_std_17 CXX_FEATURE_FOUND)
@@ -103,8 +102,7 @@ ament_export_dependencies(
     tf2_ros
     tf2_eigen
     EIGEN3
-    tesseract
-    orocos_kdl)
+    tesseract)
 
 ament_export_include_directories(include)
 

--- a/tesseract_ros/tesseract_monitoring/package.xml
+++ b/tesseract_ros/tesseract_monitoring/package.xml
@@ -13,7 +13,7 @@
   <build_export_depend>rclcpp</build_export_depend>
   <exec_depend>rclcpp</exec_depend>
   <depend>eigen</depend>
-  <depend>orocos-kdl</depend>
+  <depend>liborocos-kdl</depend>
   <depend>tesseract</depend>
   <depend>tesseract_rosutils</depend>
   <depend>tesseract_msgs</depend>

--- a/tesseract_ros/tesseract_monitoring/package.xml
+++ b/tesseract_ros/tesseract_monitoring/package.xml
@@ -13,7 +13,6 @@
   <build_export_depend>rclcpp</build_export_depend>
   <exec_depend>rclcpp</exec_depend>
   <depend>eigen</depend>
-  <depend>liborocos-kdl</depend>
   <depend>tesseract</depend>
   <depend>tesseract_rosutils</depend>
   <depend>tesseract_msgs</depend>


### PR DESCRIPTION
According to [`rosdep/base.yaml`](https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml) we should use `liborocos-kdl` instead.