### PR TITLE
Adds TesseractInitInfo Message

### DIFF
--- a/tesseract_ros/tesseract_msgs/CMakeLists.txt
+++ b/tesseract_ros/tesseract_msgs/CMakeLists.txt
@@ -42,6 +42,7 @@ set(msg_files
     "msg/Material.msg"
     "msg/Mesh.msg"
     "msg/ObjectColor.msg"
+    "msg/SceneGraph.msg"
     "msg/TesseractState.msg"
     "msg/Trajectory.msg"
     "msg/VisualGeometry.msg"

--- a/tesseract_ros/tesseract_msgs/CMakeLists.txt
+++ b/tesseract_ros/tesseract_msgs/CMakeLists.txt
@@ -43,6 +43,7 @@ set(msg_files
     "msg/Mesh.msg"
     "msg/ObjectColor.msg"
     "msg/SceneGraph.msg"
+    "msg/TesseractInitInfo.msg"
     "msg/TesseractState.msg"
     "msg/Trajectory.msg"
     "msg/VisualGeometry.msg"

--- a/tesseract_ros/tesseract_msgs/msg/SceneGraph.msg
+++ b/tesseract_ros/tesseract_msgs/msg/SceneGraph.msg
@@ -1,0 +1,8 @@
+# Message containing all information necessary to recreate a Tesseract Scene Graph
+string graph_name
+string graph_root
+
+tesseract_msgs/Link[] link_list
+tesseract_msgs/Joint[] joint_list
+
+tesseract_msgs/AllowedCollisionEntry[] acm

--- a/tesseract_ros/tesseract_msgs/msg/TesseractInitInfo.msg
+++ b/tesseract_ros/tesseract_msgs/msg/TesseractInitInfo.msg
@@ -1,0 +1,24 @@
+# TesseractInitType
+uint8 SCENE_GRAPH=0
+uint8 SCENE_GRAPH_SRDF_MODEL=1
+uint8 URDF_STRING=2
+uint8 URDF_STRING_SRDF_STRING=3
+uint8 URDF_PATH=4
+uint8 URDF_PATH_SRDF_PATH=5
+
+# Specifies the type of constructor to use. Indicates which of the fields below have valid data
+uint8 type
+
+
+# SCENE_GRAPH
+tesseract_msgs/SceneGraph scene_graph
+
+# URDF_STRING or URDF_STRING_SRDF_STRING
+string urdf_string
+# URDF_STRING_SRDF_STRING
+string srdf_string
+
+# URDF_PATH or URDF_PATH_SRDF_PATH
+string urdf_path
+# URDF_PATH_SRDF_PATH
+string srdf_path

--- a/tesseract_ros/tesseract_msgs/msg/TesseractState.msg
+++ b/tesseract_ros/tesseract_msgs/msg/TesseractState.msg
@@ -7,3 +7,6 @@ sensor_msgs/JointState joint_state
 
 # Joints that may have multiple DOF are specified here
 sensor_msgs/MultiDOFJointState multi_dof_joint_state
+
+# Initial state on which the commands are applied
+tesseract_msgs/TesseractInitInfo initial_state

--- a/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
+++ b/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
@@ -51,6 +51,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tesseract_msgs/msg/joint_limits.hpp>
 #include <tesseract_msgs/msg/joint_mimic.hpp>
 #include <tesseract_msgs/msg/joint_safety.hpp>
+#include <tesseract_msgs/msg/scene_graph.hpp>
 
 #include <tesseract_environment/core/environment.h>
 #include <Eigen/Geometry>
@@ -995,6 +996,68 @@ static inline tesseract_scene_graph::Joint fromMsg(const tesseract_msgs::msg::Jo
   fromMsg(joint.mimic, joint_msg.mimic);
 
   return joint;
+}
+
+static inline bool toMsg(tesseract_msgs::msg::SceneGraph& scene_graph_msg, const tesseract_scene_graph::SceneGraph& scene_graph)
+{
+  bool success = true;
+  // Get all links
+  scene_graph_msg.link_list.resize(scene_graph.getLinks().size());
+  for (std::size_t ind = 0; ind < scene_graph.getLinks().size(); ind++)
+    success &= toMsg(scene_graph_msg.link_list[ind], *scene_graph.getLinks()[ind]);
+
+  // Get all joints
+  scene_graph_msg.joint_list.resize(scene_graph.getJoints().size());
+  for (std::size_t ind = 0; ind < scene_graph.getJoints().size(); ind++)
+    success &= toMsg(scene_graph_msg.joint_list[ind], *scene_graph.getJoints()[ind]);
+
+  // Get ACM
+  auto acm = scene_graph.getAllowedCollisionMatrix();
+  auto pairs = acm->getAllAllowedCollisions();
+  scene_graph_msg.acm.resize(pairs.size());
+  std::size_t ind = 0;
+  for (auto& pair : pairs)
+  {
+    scene_graph_msg.acm[ind].link_1 = pair.first.first;
+    scene_graph_msg.acm[ind].link_2 = pair.first.second;
+    scene_graph_msg.acm[ind].reason = pair.second;
+  }
+
+  // Get graph specific information
+  scene_graph_msg.graph_name = scene_graph.getName();
+  scene_graph_msg.graph_root = scene_graph.getRoot();
+  return success;
+}
+
+static inline tesseract_scene_graph::SceneGraph fromMsg(const tesseract_msgs::msg::SceneGraph& scene_graph_msg)
+{
+  tesseract_scene_graph::SceneGraph scene_graph;
+
+  // Add all links
+  for (auto& link_msg : scene_graph_msg.link_list)
+  {
+    tesseract_scene_graph::Link link(link_msg.name);
+    fromMsg(link, link_msg);
+    scene_graph.addLink(std::move(link));
+  }
+
+  // Add all joints
+  for (auto& joint_msg : scene_graph_msg.joint_list)
+  {
+    tesseract_scene_graph::Joint joint(joint_msg.name);
+    fromMsg(joint, joint_msg);
+    scene_graph.addJoint(std::move(joint));
+  }
+
+  // Add ACM
+  for (auto& pair : scene_graph_msg.acm)
+    scene_graph.addAllowedCollision(pair.link_1, pair.link_2, pair.reason);
+
+  // Add graph specific information
+  scene_graph.setName(scene_graph_msg.graph_name);
+  scene_graph.setRoot(scene_graph_msg.graph_root);
+
+  return std::move(scene_graph);
 }
 
 static inline void toMsg(sensor_msgs::msg::JointState& joint_state, const tesseract_environment::EnvState& state)


### PR DESCRIPTION
In ROS 1 the robot description was on the global parameter server. We used that as the assumed initial state of the Tesseract. Since that doesn't exist in ROS 2 this will add it to the TesseractState message.
